### PR TITLE
HttpClientFactory

### DIFF
--- a/Seq.Client.Portable/Client/Portable/DefaultHttpClientFactory.cs
+++ b/Seq.Client.Portable/Client/Portable/DefaultHttpClientFactory.cs
@@ -1,0 +1,28 @@
+﻿// Seq Client for .NET - Copyright 2014 Continuous IT Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net.Http;
+
+namespace Seq.Client.Portable
+{
+    public class DefaultHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateHttpClient(Uri baseUri)
+        {
+            var client = new HttpClient { BaseAddress = baseUri };
+            return client;
+        }
+    }
+}

--- a/Seq.Client.Portable/Client/Portable/IHttpClientFactory.cs
+++ b/Seq.Client.Portable/Client/Portable/IHttpClientFactory.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2014 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net.Http;
+
+namespace Seq.Client.Portable
+{
+    /// <summary>
+    /// Interface for a factory that provides instances of <see cref="HttpClient"/>.
+    /// </summary>
+    public interface IHttpClientFactory
+    {
+        HttpClient CreateHttpClient(Uri baseUri);
+    }
+}

--- a/Seq.Client.Portable/Client/Portable/PortableSeqSink.cs
+++ b/Seq.Client.Portable/Client/Portable/PortableSeqSink.cs
@@ -27,6 +27,7 @@ namespace Seq.Client.Portable
     class PortableSeqSink : PortablePeriodicBatchingSink
     {
         readonly string _apiKey;
+        readonly IHttpClientFactory _httpClientFactory;
         readonly HttpClient _httpClient;
         const string BulkUploadResource = "api/events/raw";
         const string ApiKeyHeaderName = "X-Seq-ApiKey";
@@ -35,17 +36,18 @@ namespace Seq.Client.Portable
         public const int DefaultBatchPostingLimit = 1000;
         public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
 
-        public PortableSeqSink(string serverUrl, string apiKey, int batchPostingLimit, TimeSpan period)
+        public PortableSeqSink(string serverUrl, string apiKey, int batchPostingLimit, TimeSpan period, IHttpClientFactory httpClientFactory)
             : base(batchPostingLimit, period)
         {
             if (serverUrl == null) throw new ArgumentNullException("serverUrl");
             _apiKey = apiKey;
+            _httpClientFactory = httpClientFactory;
 
             var baseUri = serverUrl;
             if (!baseUri.EndsWith("/"))
                 baseUri += "/";
 
-            _httpClient = new HttpClient { BaseAddress = new Uri(baseUri) };
+            _httpClient = _httpClientFactory.CreateHttpClient(new Uri(baseUri));
         }
 
         protected override void Dispose(bool disposing)

--- a/Seq.Client.Portable/LoggerSinkConfigurationExtensions.cs
+++ b/Seq.Client.Portable/LoggerSinkConfigurationExtensions.cs
@@ -31,7 +31,8 @@ namespace Seq
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = PortableSeqSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            string apiKey = null, IHttpClientFactory httpClientFactory = null)
+            string apiKey = null, 
+            IHttpClientFactory httpClientFactory = null)
         {
             if (loggerSinkConfiguration == null) throw new ArgumentNullException("loggerSinkConfiguration");
             if (serverUrl == null) throw new ArgumentNullException("serverUrl");

--- a/Seq.Client.Portable/LoggerSinkConfigurationExtensions.cs
+++ b/Seq.Client.Portable/LoggerSinkConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 using Seq.Client.Portable;
 using Serilog;
 using Serilog.Configuration;
@@ -21,6 +22,7 @@ namespace Seq
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="apiKey">A Seq <i>API key</i> that authenticates the client to the Seq server.</param>
+        /// <param name="httpClientFactory">A custom factory that will be used to obtain an <see cref="HttpClient"/> instance.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration SeqPortable(
@@ -29,15 +31,16 @@ namespace Seq
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = PortableSeqSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            string apiKey = null)
+            string apiKey = null, IHttpClientFactory httpClientFactory = null)
         {
             if (loggerSinkConfiguration == null) throw new ArgumentNullException("loggerSinkConfiguration");
             if (serverUrl == null) throw new ArgumentNullException("serverUrl");
 
             var defaultedPeriod = period ?? PortableSeqSink.DefaultPeriod;
+            httpClientFactory = httpClientFactory ?? new DefaultHttpClientFactory();
 
             return loggerSinkConfiguration.Sink(
-                new PortableSeqSink(serverUrl, apiKey, batchPostingLimit, defaultedPeriod),
+                new PortableSeqSink(serverUrl, apiKey, batchPostingLimit, defaultedPeriod, httpClientFactory),
                 restrictedToMinimumLevel);
         }
     }

--- a/Seq.Client.Portable/Seq.Client.Portable.csproj
+++ b/Seq.Client.Portable/Seq.Client.Portable.csproj
@@ -34,6 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Client\Portable\DefaultHttpClientFactory.cs" />
+    <Compile Include="Client\Portable\IHttpClientFactory.cs" />
     <Compile Include="Client\Portable\PortableBatchedConnectionStatus.cs" />
     <Compile Include="Client\Portable\PortablePeriodicBatchingSink.cs" />
     <Compile Include="Client\Portable\PortableSeqApi.cs" />


### PR DESCRIPTION
This allows people to plug in their own HttpClient instance.

The main use case I can see is it will allow people to use ModernHttpClient if they want - which apparently performs better on devices.

There also appears to be a bug with the default HttpClient - in that it doesn't appear to honour the Android system proxy settings. Switching to ModernHttpClient fixes this issue: continuousit/seq-releases#348
